### PR TITLE
Fix width of code display box on reload

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,7 +6,7 @@ import tailwind from "@astrojs/tailwind";
 const manifest = {
   name: "ACES Snippets",
   short_name: "ACES Snippets",
-  start_url: "/",
+  start_url: "/snippets/",
   description: "Collection of useful code snippets",
   icons: [
     {

--- a/src/layouts/SubmissionLayout.astro
+++ b/src/layouts/SubmissionLayout.astro
@@ -53,7 +53,7 @@ const { frontmatter } = Astro.props
       }, 700)
     }
 
-    document.addEventListener('astro:after-swap', enableCopyButton)
+    document.addEventListener('astro:page-load', enableCopyButton)
   </script>
   <slot />
 </BaseLayout>


### PR DESCRIPTION
This PR fixes display of submitted code on details page
Solved by making the JavaScript code run on page load event instead of transition swap event